### PR TITLE
[bugfix] fix missing third_party folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,9 @@ pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorc
 pip install --upgrade pip
 pip install 'isaacsim[all,extscache]==4.5.0' --extra-index-url https://pypi.nvidia.com
 
+# create third_party dir
+mkdir -p third_party
+
 # IsaacLab
 cd third_party
 git clone https://github.com/isaac-sim/IsaacLab.git


### PR DESCRIPTION
added `mkdir -p third_party` in installation script to avoid failure of `cd third_party`