### PR TITLE
fix(monkey_patch): guard against IsaacLab API version mismatches

### DIFF
--- a/lw_benchhub/utils/monkey_patch.py
+++ b/lw_benchhub/utils/monkey_patch.py
@@ -519,10 +519,15 @@ def patch_reward_manager():
 
 
 def patch_create_teleop_device():
+    try:
+        from isaaclab.devices.teleop_device_factory import DEVICE_MAP, RETARGETER_MAP  # noqa: F401
+    except ImportError:
+        # Local IsaacLab uses class_type-based factory (no DEVICE_MAP dict).
+        # The existing create_teleop_device is already compatible — skip patch.
+        return
     import isaaclab.devices.teleop_device_factory as teleop_device_factory
     from isaaclab.devices import DeviceBase, DeviceCfg
     from collections.abc import Callable
-    from isaaclab.devices.teleop_device_factory import DEVICE_MAP, RETARGETER_MAP
     import inspect
     import omni
 
@@ -645,6 +650,41 @@ def patch_isaaclab_tasks_mdp():
         sys._lw_benchhub_mdp_patcher_registered = True
 
 
+def patch_xform_prim_view():
+    """Skip xform-op validation for prims that can't be standardized.
+
+    Robocasa kitchen USDs store transforms with non-standard op stacks
+    (e.g. rotateXYZ, transform matrix, or scale ops with wrong precision).
+    IsaacLab's XformPrimView validates the stack and raises ValueError on
+    mismatch.  For scene-fixture group prims (used as reference markers, not
+    moved at runtime) strict validation is unnecessary.  This patch silently
+    skips validation when the prim doesn't pass the standard check rather than
+    crashing the entire env creation.
+    """
+    try:
+        from isaaclab.sim.views.xform_prim_view import XformPrimView
+        import isaaclab.sim.utils as sim_utils
+    except ImportError:
+        return
+
+    _original_init = XformPrimView.__init__
+
+    def _patched_init(self, prim_path, device="cpu", stage=None, validate_xform_ops=True):
+        if validate_xform_ops:
+            _stage = sim_utils.get_current_stage() if stage is None else stage
+            # If any matching prim fails the standard-ops check, disable
+            # validation for this view (Robocasa group prims have non-standard
+            # xform stacks that can't always be fixed in-place).
+            for prim in sim_utils.find_matching_prims(prim_path, stage=_stage):
+                if not sim_utils.validate_standard_xform_ops(prim):
+                    validate_xform_ops = False
+                    break
+        _original_init(self, prim_path, device=device, stage=stage,
+                       validate_xform_ops=validate_xform_ops)
+
+    XformPrimView.__init__ = _patched_init
+
+
 patch_reset()
 patch_configclass()
 patch_recorder_manager_ep_meta()
@@ -653,4 +693,5 @@ patch_step()
 patch_yaml_load()
 patch_reward_manager()
 patch_create_teleop_device()
+patch_xform_prim_view()
 patch_isaaclab_tasks_mdp()


### PR DESCRIPTION
## Summary

- **`patch_create_teleop_device`**: wraps the `DEVICE_MAP`/`RETARGETER_MAP` import in `try/except ImportError`. Newer IsaacLab versions replaced the dict-based device lookup with a `class_type`-based factory and no longer export those symbols. When absent, the existing `create_teleop_device` implementation is already correct, so the patch is simply skipped.

- **`patch_xform_prim_view`** (new): Robocasa kitchen USD scenes contain fixture group prims (`counter_*_group`, `cabinet_*_group`) whose xform op stacks use non-standard encodings (rotateXYZ, transform matrix, or scale ops with mismatched precision). IsaacLab's `XformPrimView` now validates the stack and raises `ValueError` on mismatch. Calling `standardize_xform_ops()` on these prims also fails because it does not reset `xformOpOrder` before adding new ops. Since these prims are scene reference markers that are never moved at runtime, strict validation is unnecessary. The patch disables validation for any view whose prims do not pass `validate_standard_xform_ops()`, allowing env creation to proceed without modifying the USD asset.

## Test plan

- [ ] Import `lw_benchhub` with a local IsaacLab that does not export `DEVICE_MAP` — no `ImportError`
- [ ] Create a Robocasa kitchen env (`LiftObj` task) — scene loads without `ValueError` on counter/cabinet group prims
- [ ] Existing teleop/device functionality unaffected when `DEVICE_MAP` is present (patch skips itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)