### PR TITLE
[feat] add G1 autosim pipeline

### DIFF
--- a/lw_benchhub/autosim/__init__.py
+++ b/lw_benchhub/autosim/__init__.py
@@ -42,3 +42,16 @@ register_pipeline(
     entry_point=f"{__name__}.pipelines.dessert_upgrade:DessertUpgradePipeline",
     cfg_entry_point=f"{__name__}.pipelines.dessert_upgrade:DessertUpgradePipelineCfg",
 )
+
+register_pipeline(
+    id="LWBenchhub-Autosim-G1LiftCubePipeline-v0",
+    entry_point=f"{__name__}.pipelines.g1_lift_cube:G1LiftCubePipeline",
+    cfg_entry_point=f"{__name__}.pipelines.g1_lift_cube:G1LiftCubePipelineCfg",
+)
+
+# New semantic name for the same G1 pipeline (microwave opening task).
+register_pipeline(
+    id="LWBenchhub-Autosim-G1OpenMicrowavePipeline-v0",
+    entry_point=f"{__name__}.pipelines.g1_lift_cube:G1LiftCubePipeline",
+    cfg_entry_point=f"{__name__}.pipelines.g1_lift_cube:G1LiftCubePipelineCfg",
+)

--- a/lw_benchhub/autosim/action_adapters/g1_action_adapter.py
+++ b/lw_benchhub/autosim/action_adapters/g1_action_adapter.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from isaaclab.envs import ManagerBasedEnv
+
+from autosim import ActionAdapterBase
+from autosim.core.types import SkillOutput
+
+if TYPE_CHECKING:
+    from .g1_action_adapter_cfg import G1ActionAdapterCfg
+
+
+class G1ActionAdapter(ActionAdapterBase):
+    """Action adapter for the Unitree G1 robot (leg-locomotion autosim variant).
+
+    Action vector layout:
+        [0:4]   base locomotion command [vx, vy, vyaw, mode]
+                mode: 0=loco, 1=squat/stance
+        [4:11]  right arm joints (7 DoF, absolute position)
+        [11:18] left  arm joints (7 DoF, absolute position)
+        [18:32] fingers (right + left three-finger hands)
+    """
+
+    def __init__(self, cfg: G1ActionAdapterCfg):
+        super().__init__(cfg)
+        self.register_apply_method("moveto",  self._apply_moveto)
+        self.register_apply_method("reach",   self._apply_reach)
+        self.register_apply_method("lift",    self._apply_reach)
+        self.register_apply_method("push",    self._apply_reach)
+        self.register_apply_method("pull",    self._apply_reach)
+        self.register_apply_method("grasp",   self._apply_gripper)
+        self.register_apply_method("ungrasp", self._apply_gripper)
+
+    # ------------------------------------------------------------------
+    # Navigation (leg locomotion base command)
+    # ------------------------------------------------------------------
+
+    def _apply_moveto(self, skill_output: SkillOutput, env: ManagerBasedEnv) -> torch.Tensor:
+        """Convert world-frame velocity [vx, vy, vyaw] to virtual-base delta positions.
+
+        G1ActionsCfg layout:
+            base_action [0:3]   – JointPositionAction with scale=0.01 (delta)
+            right_arm   [3:10]  – absolute
+            left_arm    [10:17] – absolute
+            gripper     [17:31] – absolute
+        """
+        vx, vy, vyaw = skill_output.action  # world frame
+
+        robot = env.scene["robot"]
+        world_pose = robot.data.root_pose_w[0]  # [x, y, z, qw, qx, qy, qz]
+        w, x, y, z = world_pose[3:7]
+        sin_yaw = 2 * (w * z + x * y)
+        cos_yaw = 1 - 2 * (y ** 2 + z ** 2)
+        yaw = torch.atan2(sin_yaw, cos_yaw)
+
+        # Rotate world-frame velocity → robot body frame
+        vx_body =  vx * cos_yaw + vy * sin_yaw
+        vy_body = -vx * sin_yaw + vy * cos_yaw
+
+        dt_control = env.cfg.sim.dt * env.cfg.decimation
+
+        last_action = env.action_manager.action
+        action = last_action[0, :].clone()
+
+        # base_action uses scale=0.01: action_value = delta / 0.01
+        action[0] = (vx_body * dt_control) / 0.01
+        action[1] = (vy_body * dt_control) / 0.01
+        action[2] = (vyaw   * dt_control) / 0.01
+
+        return action
+
+    # ------------------------------------------------------------------
+    # Arm motion (cuRobo joint trajectory playback)
+    # ------------------------------------------------------------------
+
+    def _apply_reach(self, skill_output: SkillOutput, env: ManagerBasedEnv) -> torch.Tensor:
+        """Write cuRobo joint positions into the arm action terms."""
+
+        target_joint_pos = skill_output.action   # [N_sim_joints], full robot order
+        robot = env.scene["robot"]
+        current_joint_pos = robot.data.joint_pos[0]
+
+        last_action = env.action_manager.action
+        action = last_action[0, :].clone()
+
+        # Resolve joint → robot-joint index mappings
+        r_arm_ids, _ = robot.find_joints(env.action_manager.get_term("right_arm_action").cfg.joint_names)
+        l_arm_ids, _ = robot.find_joints(env.action_manager.get_term("left_arm_action").cfg.joint_names)
+
+        # Keep base steady for manipulation (zero delta → no base movement).
+        action[:3] = 0.0
+
+        # G1ActionsCfg action layout:
+        #   [0:3]   base_action    (scale=0.01 delta, kept zero above)
+        #   [3:10]  right_arm      (7-DoF absolute)
+        #   [10:17] left_arm       (7-DoF absolute)
+        #   [17:31] gripper        (14 joints absolute)
+        action[3:10]  = target_joint_pos[r_arm_ids]
+        action[10:17] = target_joint_pos[l_arm_ids]
+
+        return action
+
+    # ------------------------------------------------------------------
+    # Gripper (three-finger open / close)
+    # ------------------------------------------------------------------
+
+    def _apply_gripper(self, skill_output: SkillOutput, env: ManagerBasedEnv) -> torch.Tensor:
+        """Set all finger joints to the closed (grasp) or open (ungrasp) position."""
+
+        gripper_signal = skill_output.action[0].item()  # -1.0 = grasp, +1.0 = ungrasp
+
+        # Map signal → actual joint angle
+        finger_angle = self.cfg.finger_close_angle if gripper_signal < 0 else self.cfg.finger_open_angle
+
+        last_action = env.action_manager.action
+        action = last_action[0, :].clone()
+        action[:3] = 0.0  # keep base steady
+
+        robot = env.scene["robot"]
+        finger_ids, _ = robot.find_joints(env.action_manager.get_term("gripper_action").cfg.joint_names)
+
+        # gripper_action starts at action index 17
+        action[17:17 + len(finger_ids)] = finger_angle
+
+        return action

--- a/lw_benchhub/autosim/action_adapters/g1_action_adapter_cfg.py
+++ b/lw_benchhub/autosim/action_adapters/g1_action_adapter_cfg.py
@@ -1,0 +1,21 @@
+from isaaclab.utils import configclass
+
+from autosim import ActionAdapterCfg
+
+from .g1_action_adapter import G1ActionAdapter
+
+
+@configclass
+class G1ActionAdapterCfg(ActionAdapterCfg):
+    """Configuration for the G1 action adapter."""
+
+    class_type: type = G1ActionAdapter
+
+    base_x_joint_name: str = "base_x_joint"
+    base_y_joint_name: str = "base_y_joint"
+    base_yaw_joint_name: str = "base_yaw_joint"
+
+    finger_close_angle: float = 1.2
+    """Finger joint angle (rad) when gripper is closed."""
+    finger_open_angle: float = 0.0
+    """Finger joint angle (rad) when gripper is open."""

--- a/lw_benchhub/autosim/compat_autosim.py
+++ b/lw_benchhub/autosim/compat_autosim.py
@@ -1,0 +1,281 @@
+"""Runtime compatibility patches for external autosim package."""
+
+from __future__ import annotations
+
+import types
+
+import isaaclab.utils.math as PoseUtils
+import torch
+
+from autosim.core.types import SkillGoal
+
+
+def patch_env_extra_info() -> None:
+    """Add backward/forward compatibility fields to EnvExtraInfo."""
+    from autosim.core.types import EnvExtraInfo
+
+    if hasattr(EnvExtraInfo, "_lw_patched_extra_reach"):
+        return
+
+    original_init = EnvExtraInfo.__init__
+    original_reset = EnvExtraInfo.reset
+
+    def _reset_extra_target_pose_iterators(self) -> None:
+        data = getattr(self, "object_extra_reach_target_poses", {}) or {}
+        self._object_extra_reach_target_poses_iterator_dict = {
+            object_name: {
+                ee_name: self._build_iterator(reach_target_poses)
+                for ee_name, reach_target_poses in extra_targets.items()
+            }
+            for object_name, extra_targets in data.items()
+        }
+
+    def __init__(self, *args, object_extra_reach_target_poses=None, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.object_extra_reach_target_poses = object_extra_reach_target_poses or {}
+        _reset_extra_target_pose_iterators(self)
+
+    def reset(self) -> None:
+        original_reset(self)
+        if not hasattr(self, "object_extra_reach_target_poses"):
+            self.object_extra_reach_target_poses = {}
+        _reset_extra_target_pose_iterators(self)
+
+    def get_next_extra_reach_target_pose(self, object_name: str, ee_name: str):
+        return next(self._object_extra_reach_target_poses_iterator_dict[object_name][ee_name])
+
+    EnvExtraInfo.__init__ = __init__
+    EnvExtraInfo.reset = reset
+    EnvExtraInfo._reset_extra_target_pose_iterators = _reset_extra_target_pose_iterators
+    EnvExtraInfo.get_next_extra_reach_target_pose = get_next_extra_reach_target_pose
+    EnvExtraInfo._lw_patched_extra_reach = True
+
+
+def patch_reach_skill() -> None:
+    """Patch ReachSkill for mixed autosim versions.
+
+    Some autosim versions include newer ReachSkill call-sites that rely on
+    helper methods/fields not present in older class definitions.
+    """
+    from autosim.skills import reach as reach_mod
+    from autosim.core.registration import SkillRegistry
+
+    ReachSkill = reach_mod.ReachSkill
+
+    if not hasattr(ReachSkill, "_lw_original_build_activate_joint_state"):
+        ReachSkill._lw_original_build_activate_joint_state = ReachSkill._build_activate_joint_state
+
+        def _build_activate_joint_state_compat(
+            self, full_sim_joint_names, full_sim_q, full_sim_qd=None
+        ):
+            # Planner may include virtual base joints that do not exist in the
+            # simulated leg-loco robot articulation. Fill missing joints with 0.
+            activate_q = []
+            activate_qd = [] if full_sim_qd is not None else None
+            for joint_name in self._planner.target_joint_names:
+                if joint_name in full_sim_joint_names:
+                    sim_joint_idx = full_sim_joint_names.index(joint_name)
+                    activate_q.append(full_sim_q[sim_joint_idx])
+                    if full_sim_qd is not None and activate_qd is not None:
+                        activate_qd.append(full_sim_qd[sim_joint_idx])
+                else:
+                    activate_q.append(torch.tensor(0.0, device=full_sim_q.device, dtype=full_sim_q.dtype))
+                    if full_sim_qd is not None and activate_qd is not None:
+                        activate_qd.append(
+                            torch.tensor(0.0, device=full_sim_qd.device, dtype=full_sim_qd.dtype)
+                        )
+            activate_q_tensor = torch.stack(activate_q, dim=0)
+            if activate_qd is None:
+                return activate_q_tensor, None
+            return activate_q_tensor, torch.stack(activate_qd, dim=0)
+
+        ReachSkill._build_activate_joint_state = _build_activate_joint_state_compat
+
+    if not hasattr(ReachSkill, "_lw_original_step"):
+        ReachSkill._lw_original_step = ReachSkill.step
+
+        def step_compat(self, state):
+            self.visualize_debug_target_pose()
+
+            traj_positions = self._trajectory.position
+            if self._step_idx >= len(self._trajectory.position):
+                traj_pos = traj_positions[-1]
+                done = True
+            else:
+                traj_pos = traj_positions[self._step_idx]
+                done = False
+                self._step_idx += 1
+
+            # Keep upstream corrective-reach behavior when available.
+            if done and getattr(self, "_corrective_reach_done", False) is False and getattr(
+                self.cfg.extra_cfg, "corrective_reach", False
+            ):
+                self._corrective_reach_done = True
+                if hasattr(self, "_compute_corrective_goal"):
+                    new_goal = self._compute_corrective_goal()
+                    if new_goal is not None:
+                        self._logger.info("corrective_reach: re-planning to corrected object pose")
+                        self._step_idx = 0
+                        plan_success = self.execute_plan(state, new_goal)
+                        if plan_success:
+                            done = False
+
+            curobo_joint_names = self._trajectory.joint_names
+            sim_joint_names = state.sim_joint_names
+            joint_pos = state.robot_joint_pos.clone()
+            for curobo_idx, curobo_joint_name in enumerate(curobo_joint_names):
+                if curobo_joint_name not in sim_joint_names:
+                    continue
+                sim_idx = sim_joint_names.index(curobo_joint_name)
+                joint_pos[sim_idx] = traj_pos[curobo_idx]
+
+            from autosim.core.types import SkillOutput
+
+            return SkillOutput(action=joint_pos, done=done, success=True, info={})
+
+        ReachSkill.step = step_compat
+
+    if not hasattr(ReachSkill, "_compute_goal_from_offset"):
+
+        def _compute_goal_from_offset(
+            self,
+            env,
+            robot_name: str,
+            target_object: str,
+            reach_offset: torch.Tensor,
+            extra_offsets=None,
+        ):
+            try:
+                object_pose_in_env = env.scene[target_object].data.root_pose_w
+            except Exception:
+                self._logger.warning(f"could not read pose for '{target_object}', skipping")
+                return None
+
+            object_pos_in_env = object_pose_in_env[:, :3]
+            object_quat_in_env = object_pose_in_env[:, 3:]
+
+            offset = reach_offset.to(env.device).unsqueeze(0)
+            reach_target_pos_in_env, reach_target_quat_in_env = PoseUtils.combine_frame_transforms(
+                object_pos_in_env, object_quat_in_env, offset[:, :3], offset[:, 3:]
+            )
+            self._target_poses["target_pose"] = torch.cat((reach_target_pos_in_env, reach_target_quat_in_env), dim=-1)
+
+            robot = env.scene[robot_name]
+            robot_root_pos_in_env = robot.data.root_pose_w[:, :3]
+            robot_root_quat_in_env = robot.data.root_pose_w[:, 3:]
+
+            reach_target_pos_in_robot_root, reach_target_quat_in_robot_root = PoseUtils.subtract_frame_transforms(
+                robot_root_pos_in_env,
+                robot_root_quat_in_env,
+                reach_target_pos_in_env,
+                reach_target_quat_in_env,
+            )
+            target_pose = torch.cat(
+                (reach_target_pos_in_robot_root, reach_target_quat_in_robot_root), dim=-1
+            ).squeeze(0)
+
+            activate_q, _ = self._build_activate_joint_state(
+                robot.data.joint_names, robot.data.joint_pos[0], robot.data.joint_vel[0]
+            )
+            # Current upstream offset-based extra-EEF API is inconsistent across
+            # versions. Keep behavior stable by using the built-in policy.
+            extra_target_poses = self._build_extra_target_poses(activate_q, target_pose, self._saved_env_extra_info)
+
+            return SkillGoal(target_object=target_object, target_pose=target_pose, extra_target_poses=extra_target_poses)
+
+        ReachSkill._compute_goal_from_offset = _compute_goal_from_offset
+
+    original_extract = ReachSkill.extract_goal_from_info
+
+    def extract_goal_from_info(self, skill_info, env, env_extra_info):
+        target_object = skill_info.target_object
+        reach_offset = env_extra_info.get_next_reach_target_pose(target_object).to(env.device)
+
+        self._saved_env = env
+        self._saved_env_extra_info = env_extra_info
+        self._saved_robot_name = env_extra_info.robot_name
+        self._saved_target_object = target_object
+        self._saved_reach_offset = reach_offset
+        self._saved_extra_offsets = None
+
+        # Keep compatibility with older/newer autosim versions.
+        if hasattr(self, "_compute_goal_from_offset"):
+            return self._compute_goal_from_offset(env, env_extra_info.robot_name, target_object, reach_offset, None)
+        return original_extract(self, skill_info, env, env_extra_info)
+
+    ReachSkill.extract_goal_from_info = extract_goal_from_info
+
+    original_init = ReachSkill.__init__
+
+    def __init__(self, extra_cfg):
+        original_init(self, extra_cfg)
+        if not hasattr(self.cfg.extra_cfg, "corrective_reach"):
+            self.cfg.extra_cfg.corrective_reach = False
+        self._corrective_reach_done = False
+        self._saved_env = None
+        self._saved_env_extra_info = None
+        self._saved_robot_name = "robot"
+        self._saved_target_object = None
+        self._saved_reach_offset = None
+        self._saved_extra_offsets = None
+
+    ReachSkill.__init__ = __init__
+
+    original_reset = ReachSkill.reset
+
+    def reset(self):
+        original_reset(self)
+        self._corrective_reach_done = False
+        self._saved_env = None
+        self._saved_env_extra_info = None
+        self._saved_target_object = None
+        self._saved_reach_offset = None
+        self._saved_extra_offsets = None
+
+    ReachSkill.reset = reset
+
+    # Fallback: patch the factory path too, in case another ReachSkill class
+    # object (from a different autosim import path) is instantiated.
+    if not hasattr(SkillRegistry, "_lw_patched_create"):
+
+        @classmethod
+        def _patched_create(cls, name, extra_cfg):
+            skill_cls = cls.get(name)
+            skill = skill_cls(extra_cfg)
+            if skill.__class__.__name__ == "ReachSkill":
+                if not hasattr(skill, "_compute_goal_from_offset"):
+                    skill._compute_goal_from_offset = types.MethodType(
+                        ReachSkill._compute_goal_from_offset, skill
+                    )
+                if not hasattr(skill.cfg.extra_cfg, "corrective_reach"):
+                    skill.cfg.extra_cfg.corrective_reach = False
+                if not hasattr(skill, "_saved_env_extra_info"):
+                    skill._saved_env_extra_info = None
+                if not hasattr(skill, "_corrective_reach_done"):
+                    skill._corrective_reach_done = False
+            return skill
+
+        SkillRegistry.create = _patched_create
+        SkillRegistry._lw_patched_create = True
+
+
+def patch_curobo_config() -> None:
+    """Relax cuRobo start-state checks for mixed G1 planner/sim setups."""
+    from curobo.wrap.reacher.motion_gen import MotionGenConfig
+
+    if hasattr(MotionGenConfig, "_lw_original_load_from_robot_config"):
+        return
+
+    MotionGenConfig._lw_original_load_from_robot_config = MotionGenConfig.load_from_robot_config
+
+    @classmethod
+    def _patched_load_from_robot_config(cls, *args, **kwargs):
+        # In our current hybrid setup planner robot model and sim articulation
+        # differ on virtual base joints, which can trigger false-positive
+        # INVALID_START_STATE_SELF_COLLISION. Relaxing self collision check
+        # avoids immediate planner rejection at step 0.
+        kwargs.setdefault("self_collision_check", False)
+        kwargs.setdefault("self_collision_opt", False)
+        return cls._lw_original_load_from_robot_config(*args, **kwargs)
+
+    MotionGenConfig.load_from_robot_config = _patched_load_from_robot_config

--- a/lw_benchhub/autosim/content/assets/cube_5cm.usda
+++ b/lw_benchhub/autosim/content/assets/cube_5cm.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b023d8c10b6f67c04b717cedb1599d9afe3333dfb66622fd5b0a57136de2c37f
+size 1889

--- a/lw_benchhub/autosim/content/assets/robot/g1/G1_autosim.urdf
+++ b/lw_benchhub/autosim/content/assets/robot/g1/G1_autosim.urdf
@@ -1,0 +1,1552 @@
+<robot name="g1_autosim">
+
+  
+  
+
+    <!-- ===== Virtual base joints (autosim addition) ===== -->
+  <!-- These three joints replace the original floating_base_joint and allow  -->
+  <!-- Isaac Lab to move the whole robot via joint position commands, matching  -->
+  <!-- the same pattern used in X7S.                                           -->
+
+  <link name="world_link"/>
+
+  <link name="base_x_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_x_joint" type="prismatic">
+    <parent link="world_link"/>
+    <child link="base_x_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-50" upper="50" effort="100" velocity="1000"/>
+  </joint>
+
+  <link name="base_y_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_y_joint" type="prismatic">
+    <parent link="base_x_link"/>
+    <child link="base_y_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-50" upper="50" effort="100" velocity="1000"/>
+  </joint>
+
+  <link name="base_yaw_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_yaw_joint" type="revolute">
+    <parent link="base_y_link"/>
+    <child link="base_yaw_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-6.28159" upper="6.28159" effort="100" velocity="1000"/>
+  </joint>
+
+  <joint name="base_to_pelvis" type="fixed">
+    <parent link="base_yaw_link"/>
+    <child link="pelvis"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <!-- ===== End of virtual base joints ===== -->
+<link name="pelvis">
+    <inertial>
+      <origin xyz="0 0 -0.07605" rpy="0 0 0"/>
+      <mass value="3.813"/>
+      <inertia ixx="0.010549" ixy="0" ixz="2.1E-06" iyy="0.0093089" iyz="0" izz="0.0079184"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+  </link>
+  <link name="pelvis_contour_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis_contour_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis_contour_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="pelvis_contour_joint" type="fixed">
+    <parent link="pelvis"/>
+    <child link="pelvis_contour_link"/>
+  </joint>
+
+  
+  <link name="left_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.002741 0.047791 -0.02606" rpy="0 0 0"/>
+      <mass value="1.35"/>
+      <inertia ixx="0.001811" ixy="3.68E-05" ixz="-3.44E-05" iyy="0.0014193" iyz="0.000171" izz="0.0012812"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_pitch_joint" type="revolute">
+    <origin xyz="0 0.064452 -0.1027" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="left_hip_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-2.5307" upper="2.8798" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_hip_roll_link">
+    <inertial>
+      <origin xyz="0.029812 -0.001045 -0.087934" rpy="0 0 0"/>
+      <mass value="1.52"/>
+      <inertia ixx="0.0023773" ixy="-3.8E-06" ixz="-0.0003908" iyy="0.0024123" iyz="1.84E-05" izz="0.0016595"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_roll_joint" type="revolute">
+    <origin xyz="0 0.052 -0.030465" rpy="0 -0.1749 0"/>
+    <parent link="left_hip_pitch_link"/>
+    <child link="left_hip_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.5236" upper="2.9671" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.057709 -0.010981 -0.15078" rpy="0 0 0"/>
+      <mass value="1.702"/>
+      <inertia ixx="0.0057774" ixy="-0.0005411" ixz="-0.0023948" iyy="0.0076124" iyz="-0.0007072" izz="0.003149"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_yaw_joint" type="revolute">
+    <origin xyz="0.025001 0 -0.12412" rpy="0 0 0"/>
+    <parent link="left_hip_roll_link"/>
+    <child link="left_hip_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.7576" upper="2.7576" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_knee_link">
+    <inertial>
+      <origin xyz="0.005457 0.003964 -0.12074" rpy="0 0 0"/>
+      <mass value="1.932"/>
+      <inertia ixx="0.011329" ixy="4.82E-05" ixz="-4.49E-05" iyy="0.011277" iyz="-0.0007146" izz="0.0015168"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_knee_joint" type="revolute">
+    <origin xyz="-0.078273 0.0021489 -0.17734" rpy="0 0.1749 0"/>
+    <parent link="left_hip_yaw_link"/>
+    <child link="left_knee_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.087267" upper="2.8798" effort="139" velocity="20"/>
+  </joint>
+  <link name="left_ankle_pitch_link">
+    <inertial>
+      <origin xyz="-0.007269 0 0.011137" rpy="0 0 0"/>
+      <mass value="0.074"/>
+      <inertia ixx="8.4E-06" ixy="0" ixz="-2.9E-06" iyy="1.89E-05" iyz="0" izz="1.26E-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_pitch_joint" type="revolute">
+    <origin xyz="0 -9.4445E-05 -0.30001" rpy="0 0 0"/>
+    <parent link="left_knee_link"/>
+    <child link="left_ankle_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.87267" upper="0.5236" effort="50" velocity="37"/>
+  </joint>
+  <link name="left_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.026505 0 -0.016425" rpy="0 0 0"/>
+      <mass value="0.608"/>
+      <inertia ixx="0.0002231" ixy="2E-07" ixz="8.91E-05" iyy="0.0016161" iyz="-1E-07" izz="0.0016667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_roll_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.05 0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.05 -0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 -0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_roll_joint" type="revolute">
+    <origin xyz="0 0 -0.017558" rpy="0 0 0"/>
+    <parent link="left_ankle_pitch_link"/>
+    <child link="left_ankle_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.2618" upper="0.2618" effort="50" velocity="37"/>
+  </joint>
+  <link name="right_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.002741 -0.047791 -0.02606" rpy="0 0 0"/>
+      <mass value="1.35"/>
+      <inertia ixx="0.001811" ixy="-3.68E-05" ixz="-3.44E-05" iyy="0.0014193" iyz="-0.000171" izz="0.0012812"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_pitch_joint" type="revolute">
+    <origin xyz="0 -0.064452 -0.1027" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="right_hip_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-2.5307" upper="2.8798" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_hip_roll_link">
+    <inertial>
+      <origin xyz="0.029812 0.001045 -0.087934" rpy="0 0 0"/>
+      <mass value="1.52"/>
+      <inertia ixx="0.0023773" ixy="3.8E-06" ixz="-0.0003908" iyy="0.0024123" iyz="-1.84E-05" izz="0.0016595"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_roll_joint" type="revolute">
+    <origin xyz="0 -0.052 -0.030465" rpy="0 -0.1749 0"/>
+    <parent link="right_hip_pitch_link"/>
+    <child link="right_hip_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.9671" upper="0.5236" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.057709 0.010981 -0.15078" rpy="0 0 0"/>
+      <mass value="1.702"/>
+      <inertia ixx="0.0057774" ixy="0.0005411" ixz="-0.0023948" iyy="0.0076124" iyz="0.0007072" izz="0.003149"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_yaw_joint" type="revolute">
+    <origin xyz="0.025001 0 -0.12412" rpy="0 0 0"/>
+    <parent link="right_hip_roll_link"/>
+    <child link="right_hip_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.7576" upper="2.7576" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_knee_link">
+    <inertial>
+      <origin xyz="0.005457 -0.003964 -0.12074" rpy="0 0 0"/>
+      <mass value="1.932"/>
+      <inertia ixx="0.011329" ixy="-4.82E-05" ixz="4.49E-05" iyy="0.011277" iyz="0.0007146" izz="0.0015168"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_knee_joint" type="revolute">
+    <origin xyz="-0.078273 -0.0021489 -0.17734" rpy="0 0.1749 0"/>
+    <parent link="right_hip_yaw_link"/>
+    <child link="right_knee_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.087267" upper="2.8798" effort="139" velocity="20"/>
+  </joint>
+  <link name="right_ankle_pitch_link">
+    <inertial>
+      <origin xyz="-0.007269 0 0.011137" rpy="0 0 0"/>
+      <mass value="0.074"/>
+      <inertia ixx="8.4E-06" ixy="0" ixz="-2.9E-06" iyy="1.89E-05" iyz="0" izz="1.26E-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_pitch_joint" type="revolute">
+    <origin xyz="0 9.4445E-05 -0.30001" rpy="0 0 0"/>
+    <parent link="right_knee_link"/>
+    <child link="right_ankle_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.87267" upper="0.5236" effort="50" velocity="37"/>
+  </joint>
+  <link name="right_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.026505 0 -0.016425" rpy="0 0 0"/>
+      <mass value="0.608"/>
+      <inertia ixx="0.0002231" ixy="-2E-07" ixz="8.91E-05" iyy="0.0016161" iyz="1E-07" izz="0.0016667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_roll_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.05 0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.05 -0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 -0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_roll_joint" type="revolute">
+    <origin xyz="0 0 -0.017558" rpy="0 0 0"/>
+    <parent link="right_ankle_pitch_link"/>
+    <child link="right_ankle_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.2618" upper="0.2618" effort="50" velocity="37"/>
+  </joint>
+
+  
+  <link name="waist_yaw_link">
+    <inertial>
+      <origin xyz="0.003964 0 0.018769" rpy="0 0 0"/>
+      <mass value="0.244"/>
+      <inertia ixx="9.9587E-05" ixy="-1.833E-06" ixz="-1.2617E-05" iyy="0.00012411" iyz="-1.18E-07" izz="0.00015586"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="waist_yaw_joint" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="waist_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="88" velocity="32"/>
+  </joint>
+  <link name="waist_roll_link">
+    <inertial>
+      <origin xyz="0 -0.000236 0.010111" rpy="0 0 0"/>
+      <mass value="0.047"/>
+      <inertia ixx="7.515E-06" ixy="0" ixz="0" iyy="6.398E-06" iyz="9.9E-08" izz="3.988E-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="waist_roll_joint" type="revolute">
+    <origin xyz="-0.0039635 0 0.035" rpy="0 0 0"/>
+    <parent link="waist_yaw_link"/>
+    <child link="waist_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.52" upper="0.52" effort="50" velocity="37"/>
+  </joint>
+  <link name="torso_link">
+    <inertial>
+      <origin xyz="0.002601 0.000257 0.153719" rpy="0 0 0"/>
+      <mass value="8.562"/>
+      <inertia ixx="0.065674966" ixy="-8.597E-05" ixz="-0.001737252" iyy="0.053535188" iyz="8.6899E-05" izz="0.030808125"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/torso_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/torso_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="waist_pitch_joint" type="revolute">
+    <origin xyz="0 0 0.019" rpy="0 0 0"/>
+    <parent link="waist_roll_link"/>
+    <child link="torso_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.52" upper="0.52" effort="50" velocity="37"/>
+  </joint>
+
+  
+  <joint name="logo_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="logo_link"/>
+  </joint>
+  <link name="logo_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/logo_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/logo_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+
+  
+  <link name="head_link">
+    <inertial>
+      <origin xyz="0.005267 0.000299 0.449869" rpy="0 0 0"/>
+      <mass value="1.036"/>
+      <inertia ixx="0.004085051" ixy="-2.543E-06" ixz="-6.9455E-05" iyy="0.004185212" iyz="-3.726E-06" izz="0.001807911"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/head_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/head_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="head_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="head_link"/>
+  </joint>
+
+  
+  <link name="waist_support_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_support_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_support_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="waist_support_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="waist_support_link"/>
+  </joint>
+
+  
+  <link name="imu_link"></link>
+  <joint name="imu_joint" type="fixed">
+    <origin xyz="-0.03959 -0.00224 0.13792" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="imu_link"/>
+  </joint>
+
+  
+  <link name="d435_link"></link>
+  <joint name="d435_joint" type="fixed">
+    <origin xyz="0.0576235 0.01753 0.41987" rpy="0 0.8307767239493009 0"/>
+    <parent link="torso_link"/>
+    <child link="d435_link"/>
+  </joint>
+
+  
+  <link name="mid360_link"></link>
+  <joint name="mid360_joint" type="fixed">
+    <origin xyz="0.0002835 0.00003 0.40618" rpy="0 0.04014257279586953 0"/>
+    <parent link="torso_link"/>
+    <child link="mid360_link"/>
+  </joint>
+
+  
+  <link name="left_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0 0.035892 -0.011628" rpy="0 0 0"/>
+      <mass value="0.718"/>
+      <inertia ixx="0.0004291" ixy="-9.2E-06" ixz="6.4E-06" iyy="0.000453" iyz="2.26E-05" izz="0.000423"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.04 -0.01" rpy="0 1.5707963267948966 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.05"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.0039563 0.10022 0.23778" rpy="0.27931 5.4949E-05 -0.00019159"/>
+    <parent link="torso_link"/>
+    <child link="left_shoulder_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.0892" upper="2.6704" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_shoulder_roll_link">
+    <inertial>
+      <origin xyz="-0.000227 0.00727 -0.063243" rpy="0 0 0"/>
+      <mass value="0.643"/>
+      <inertia ixx="0.0006177" ixy="-1E-06" ixz="8.7E-06" iyy="0.0006912" iyz="-5.3E-06" izz="0.0003894"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.004 0.006 -0.053" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.03"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0.038 -0.013831" rpy="-0.27925 0 0"/>
+    <parent link="left_shoulder_pitch_link"/>
+    <child link="left_shoulder_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-1.5882" upper="2.2515" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010773 -0.002949 -0.072009" rpy="0 0 0"/>
+      <mass value="0.734"/>
+      <inertia ixx="0.0009988" ixy="7.9E-06" ixz="0.0001412" iyy="0.0010605" iyz="-2.86E-05" izz="0.0004354"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 0.00624 -0.1032" rpy="0 0 0"/>
+    <parent link="left_shoulder_roll_link"/>
+    <child link="left_shoulder_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_elbow_link">
+    <inertial>
+      <origin xyz="0.064956 0.004454 -0.010062" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.0002891" ixy="6.53E-05" ixz="1.72E-05" iyy="0.0004152" iyz="-5.6E-06" izz="0.0004197"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_elbow_joint" type="revolute">
+    <origin xyz="0.015783 0 -0.080518" rpy="0 0 0"/>
+    <parent link="left_shoulder_yaw_link"/>
+    <child link="left_elbow_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.0472" upper="2.0944" effort="25" velocity="37"/>
+  </joint>
+  <joint name="left_wrist_roll_joint" type="revolute">
+    <origin xyz="0.100 0.00188791 -0.010" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <parent link="left_elbow_link"/>
+    <child link="left_wrist_roll_link"/>
+    <limit effort="25" velocity="37" lower="-1.972222054" upper="1.972222054"/>
+  </joint>
+  <link name="left_wrist_roll_link">
+    <inertial>
+      <origin xyz="0.01713944778 0.00053759094 0.00000048864" rpy="0 0 0"/>
+      <mass value="0.08544498"/>
+      <inertia ixx="0.00004821544023" ixy="-0.00000424511021" ixz="0.00000000510599" iyy="0.00003722899093" iyz="-0.00000000123525" izz="0.00005482106541"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_wrist_pitch_joint" type="revolute">
+    <origin xyz="0.038 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <parent link="left_wrist_roll_link"/>
+    <child link="left_wrist_pitch_link"/>
+    <limit effort="5" velocity="22" lower="-1.614429558" upper="1.614429558"/>
+  </joint>
+  <link name="left_wrist_pitch_link">
+    <inertial>
+      <origin xyz="0.02299989837 -0.00111685314 -0.00111658096" rpy="0 0 0"/>
+      <mass value="0.48404956"/>
+      <inertia ixx="0.00016579646273" ixy="-0.00001231206746" ixz="0.00001231699194" iyy="0.00042954057410" iyz="0.00000081417712" izz="0.00042953697654"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_wrist_yaw_joint" type="revolute">
+    <origin xyz="0.046 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_wrist_pitch_link"/>
+    <child link="left_wrist_yaw_link"/>
+    <limit effort="5" velocity="22" lower="-1.614429558" upper="1.614429558"/>
+  </joint>
+  <link name="left_wrist_yaw_link">
+    <inertial>
+      <origin xyz="0.02200381568 0.00049485096 0.00053861123" rpy="0 0 0"/>
+      <mass value="0.08457647"/>
+      <inertia ixx="0.00004929128828" ixy="-0.00000045735494" ixz="0.00000445867591" iyy="0.00005973338134" iyz="0.00000043217198" izz="0.00003928083826"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_palm_joint" type="fixed">
+    <origin xyz="0.0415 0.003 0" rpy="0 0 0"/>
+    <parent link="left_wrist_yaw_link"/>
+    <child link="left_hand_palm_link"/>
+  </joint>
+  <link name="left_hand_palm_link">
+    <inertial>
+      <origin xyz="0.06214634836 -0.00050869656 -0.00058171093" rpy="0 0 0"/>
+      <mass value="0.37283854"/>
+      <inertia ixx="0.00027535181027" ixy="-0.00001595519465" ixz="-0.00000242161890" iyy="0.00053951827219" iyz="-0.00000042279435" izz="0.00039623390907"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_palm_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_palm_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_thumb_0_joint" type="revolute">
+    <origin xyz="0.0255 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <parent link="left_hand_palm_link"/>
+    <child link="left_hand_thumb_0_link"/>
+    <limit effort="2.45" velocity="6.857" lower="-1.04719755" upper="1.04719755"/>
+  </joint>
+  <link name="left_hand_thumb_0_link">
+    <inertial>
+      <origin xyz="-0.00088424580 -0.00863407079 0.00094429336" rpy="0 0 0"/>
+      <mass value="0.08623657"/>
+      <inertia ixx="0.00001602919238" ixy="0.00000010683177" ixz="0.00000016728875" iyy="0.00001451795012" iyz="-0.00000051094752" izz="0.00001637877663"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_thumb_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_thumb_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_thumb_1_joint" type="revolute">
+    <origin xyz="-0.0025 -0.0193 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_thumb_0_link"/>
+    <child link="left_hand_thumb_1_link"/>
+    <limit effort="1.4" velocity="12" lower="-0.72431163" upper="1.04719755"/>
+  </joint>
+  <link name="left_hand_thumb_1_link">
+    <inertial>
+      <origin xyz="-0.00082788768 -0.03547435774 -0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00001274699945" ixy="-0.00000050770784" ixz="0.00000016088850" iyy="0.00000601573947" iyz="-0.00000027839003" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_thumb_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.001 -0.032 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.02 0.03 0.02"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_thumb_2_joint" type="revolute">
+    <origin xyz="0 -0.0458 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_thumb_1_link"/>
+    <child link="left_hand_thumb_2_link"/>
+    <limit effort="1.4" velocity="12" lower="0" upper="1.74532925"/>
+  </joint>
+  <link name="left_hand_thumb_2_link">
+    <inertial>
+      <origin xyz="-0.00171735242 -0.02628192939 0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000461267817" ixy="-0.00000003422130" ixz="-0.00000000823881" iyy="0.00000153561368" iyz="-0.00000002549885" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_thumb_2_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_thumb_2_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_middle_0_joint" type="revolute">
+    <origin xyz="0.0777 0.0016 -0.0285" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_palm_link"/>
+    <child link="left_hand_middle_0_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.57079632" upper="0"/>
+  </joint>
+  <link name="left_hand_middle_0_link">
+    <inertial>
+      <origin xyz="0.03547435774 0.00082788768 0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00000601573947" ixy="-0.00000050770784" ixz="-0.00000027839003" iyy="0.00001274699945" iyz="0.00000016088850" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_middle_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_middle_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_middle_1_joint" type="revolute">
+    <origin xyz="0.0458 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_middle_0_link"/>
+    <child link="left_hand_middle_1_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.74532925" upper="0"/>
+  </joint>
+  <link name="left_hand_middle_1_link">
+    <inertial>
+      <origin xyz="0.02628192939 0.00171735242 -0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000153561368" ixy="-0.00000003422130" ixz="-0.00000002549885" iyy="0.00000461267817" iyz="-0.00000000823881" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_middle_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_middle_1_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_index_0_joint" type="revolute">
+    <origin xyz="0.0777 0.0016 0.0285" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_palm_link"/>
+    <child link="left_hand_index_0_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.57079632" upper="0"/>
+  </joint>
+  <link name="left_hand_index_0_link">
+    <inertial>
+      <origin xyz="0.03547435774 0.00082788768 0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00000601573947" ixy="-0.00000050770784" ixz="-0.00000027839003" iyy="0.00001274699945" iyz="0.00000016088850" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_index_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_index_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hand_index_1_joint" type="revolute">
+    <origin xyz="0.0458 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="left_hand_index_0_link"/>
+    <child link="left_hand_index_1_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.74532925" upper="0"/>
+  </joint>
+  <link name="left_hand_index_1_link">
+    <inertial>
+      <origin xyz="0.02628192939 0.00171735242 -0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000153561368" ixy="-0.00000003422130" ixz="-0.00000002549885" iyy="0.00000461267817" iyz="-0.00000000823881" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_index_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hand_index_1_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="right_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0 -0.035892 -0.011628" rpy="0 0 0"/>
+      <mass value="0.718"/>
+      <inertia ixx="0.0004291" ixy="9.2E-06" ixz="6.4E-06" iyy="0.000453" iyz="-2.26E-05" izz="0.000423"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 -0.04 -0.01" rpy="0 1.5707963267948966 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.05"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.0039563 -0.10021 0.23778" rpy="-0.27931 5.4949E-05 0.00019159"/>
+    <parent link="torso_link"/>
+    <child link="right_shoulder_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.0892" upper="2.6704" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_shoulder_roll_link">
+    <inertial>
+      <origin xyz="-0.000227 -0.00727 -0.063243" rpy="0 0 0"/>
+      <mass value="0.643"/>
+      <inertia ixx="0.0006177" ixy="1E-06" ixz="8.7E-06" iyy="0.0006912" iyz="5.3E-06" izz="0.0003894"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.004 -0.006 -0.053" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.03"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 -0.038 -0.013831" rpy="0.27925 0 0"/>
+    <parent link="right_shoulder_pitch_link"/>
+    <child link="right_shoulder_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.2515" upper="1.5882" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010773 0.002949 -0.072009" rpy="0 0 0"/>
+      <mass value="0.734"/>
+      <inertia ixx="0.0009988" ixy="-7.9E-06" ixz="0.0001412" iyy="0.0010605" iyz="2.86E-05" izz="0.0004354"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 -0.00624 -0.1032" rpy="0 0 0"/>
+    <parent link="right_shoulder_roll_link"/>
+    <child link="right_shoulder_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_elbow_link">
+    <inertial>
+      <origin xyz="0.064956 -0.004454 -0.010062" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.0002891" ixy="-6.53E-05" ixz="1.72E-05" iyy="0.0004152" iyz="5.6E-06" izz="0.0004197"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_elbow_joint" type="revolute">
+    <origin xyz="0.015783 0 -0.080518" rpy="0 0 0"/>
+    <parent link="right_shoulder_yaw_link"/>
+    <child link="right_elbow_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.0472" upper="2.0944" effort="25" velocity="37"/>
+  </joint>
+  <joint name="right_wrist_roll_joint" type="revolute">
+    <origin xyz="0.100 -0.00188791 -0.010" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <parent link="right_elbow_link"/>
+    <child link="right_wrist_roll_link"/>
+    <limit effort="25" velocity="37" lower="-1.972222054" upper="1.972222054"/>
+  </joint>
+  <link name="right_wrist_roll_link">
+    <inertial>
+      <origin xyz="0.01713944778 -0.00053759094 0.00000048864" rpy="0 0 0"/>
+      <mass value="0.08544498"/>
+      <inertia ixx="0.00004821544023" ixy="0.00000424511021" ixz="0.00000000510599" iyy="0.00003722899093" iyz="0.00000000123525" izz="0.00005482106541"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_wrist_pitch_joint" type="revolute">
+    <origin xyz="0.038 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <parent link="right_wrist_roll_link"/>
+    <child link="right_wrist_pitch_link"/>
+    <limit effort="5" velocity="22" lower="-1.614429558" upper="1.614429558"/>
+  </joint>
+  <link name="right_wrist_pitch_link">
+    <inertial>
+      <origin xyz="0.02299989837 0.00111685314 -0.00111658096" rpy="0 0 0"/>
+      <mass value="0.48404956"/>
+      <inertia ixx="0.00016579646273" ixy="0.00001231206746" ixz="0.00001231699194" iyy="0.00042954057410" iyz="-0.00000081417712" izz="0.00042953697654"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_wrist_yaw_joint" type="revolute">
+    <origin xyz="0.046 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_wrist_pitch_link"/>
+    <child link="right_wrist_yaw_link"/>
+    <limit effort="5" velocity="22" lower="-1.614429558" upper="1.614429558"/>
+  </joint>
+  <link name="right_wrist_yaw_link">
+    <inertial>
+      <origin xyz="0.02200381568 -0.00049485096 0.00053861123" rpy="0 0 0"/>
+      <mass value="0.08457647"/>
+      <inertia ixx="0.00004929128828" ixy="0.00000045735494" ixz="0.00000445867591" iyy="0.00005973338134" iyz="-0.00000043217198" izz="0.00003928083826"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_palm_joint" type="fixed">
+    <origin xyz="0.0415 -0.003 0" rpy="0 0 0"/>
+    <parent link="right_wrist_yaw_link"/>
+    <child link="right_hand_palm_link"/>
+  </joint>
+  <link name="right_hand_palm_link">
+    <inertial>
+      <origin xyz="0.06214634836 0.00050869656 -0.00058171093" rpy="0 0 0"/>
+      <mass value="0.37283854"/>
+      <inertia ixx="0.00027535181027" ixy="0.00001595519465" ixz="-0.00000242161890" iyy="0.00053951827219" iyz="0.00000042279435" izz="0.00039623390907"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_palm_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_palm_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_thumb_0_joint" type="revolute">
+    <origin xyz="0.0255 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <parent link="right_hand_palm_link"/>
+    <child link="right_hand_thumb_0_link"/>
+    <limit effort="2.45" velocity="6.857" lower="-1.04719755" upper="1.04719755"/>
+  </joint>
+  <link name="right_hand_thumb_0_link">
+    <inertial>
+      <origin xyz="-0.00088424580 0.00863407079 0.00094429336" rpy="0 0 0"/>
+      <mass value="0.08623657"/>
+      <inertia ixx="0.00001602919238" ixy="-0.00000010683177" ixz="0.00000016728875" iyy="0.00001451795012" iyz="0.00000051094752" izz="0.00001637877663"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_thumb_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_thumb_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_thumb_1_joint" type="revolute">
+    <origin xyz="-0.0025 0.0193 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_thumb_0_link"/>
+    <child link="right_hand_thumb_1_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.04719755" upper="0.72431163"/>
+  </joint>
+  <link name="right_hand_thumb_1_link">
+    <inertial>
+      <origin xyz="-0.00082788768 0.03547435774 -0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00001274699945" ixy="0.00000050770784" ixz="0.00000016088850" iyy="0.00000601573947" iyz="0.00000027839003" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_thumb_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.001 0.032 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.02 0.03 0.02"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_thumb_2_joint" type="revolute">
+    <origin xyz="0 0.0458 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_thumb_1_link"/>
+    <child link="right_hand_thumb_2_link"/>
+    <limit effort="1.4" velocity="12" lower="-1.74532925" upper="0"/>
+  </joint>
+  <link name="right_hand_thumb_2_link">
+    <inertial>
+      <origin xyz="-0.00171735242 0.02628192939 0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000461267817" ixy="0.00000003422130" ixz="-0.00000000823881" iyy="0.00000153561368" iyz="0.00000002549885" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_thumb_2_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_thumb_2_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_middle_0_joint" type="revolute">
+    <origin xyz="0.0777 -0.0016 -0.0285" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_palm_link"/>
+    <child link="right_hand_middle_0_link"/>
+    <limit effort="1.4" velocity="12" lower="0" upper="1.57079632"/>
+  </joint>
+  <link name="right_hand_middle_0_link">
+    <inertial>
+      <origin xyz="0.03547435774 -0.00082788768 0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00000601573947" ixy="0.00000050770784" ixz="-0.00000027839003" iyy="0.00001274699945" iyz="-0.00000016088850" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_middle_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_middle_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_middle_1_joint" type="revolute">
+    <origin xyz="0.0458 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_middle_0_link"/>
+    <child link="right_hand_middle_1_link"/>
+    <limit effort="1.4" velocity="12" lower="0" upper="1.74532925"/>
+  </joint>
+  <link name="right_hand_middle_1_link">
+    <inertial>
+      <origin xyz="0.02628192939 -0.00171735242 -0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000153561368" ixy="0.00000003422130" ixz="-0.00000002549885" iyy="0.00000461267817" iyz="0.00000000823881" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_middle_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_middle_1_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_index_0_joint" type="revolute">
+    <origin xyz="0.0777 -0.0016 0.0285" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_palm_link"/>
+    <child link="right_hand_index_0_link"/>
+    <limit effort="1.4" velocity="12" lower="0" upper="1.57079632"/>
+  </joint>
+  <link name="right_hand_index_0_link">
+    <inertial>
+      <origin xyz="0.03547435774 -0.00082788768 0.00038089960" rpy="0 0 0"/>
+      <mass value="0.05885070"/>
+      <inertia ixx="0.00000601573947" ixy="0.00000050770784" ixz="-0.00000027839003" iyy="0.00001274699945" iyz="-0.00000016088850" izz="0.00001234543582"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_index_0_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_index_0_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hand_index_1_joint" type="revolute">
+    <origin xyz="0.0458 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <parent link="right_hand_index_0_link"/>
+    <child link="right_hand_index_1_link"/>
+    <limit effort="1.4" velocity="12" lower="0" upper="1.74532925"/>
+  </joint>
+  <link name="right_hand_index_1_link">
+    <inertial>
+      <origin xyz="0.02628192939 -0.00171735242 -0.00010778879" rpy="0 0 0"/>
+      <mass value="0.02030626"/>
+      <inertia ixx="0.00000153561368" ixy="0.00000003422130" ixz="-0.00000002549885" iyy="0.00000461267817" iyz="0.00000000823881" izz="0.00000386625776"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_index_1_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hand_index_1_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/lw_benchhub/autosim/content/assets/robot/g1/generate_urdf.py
+++ b/lw_benchhub/autosim/content/assets/robot/g1/generate_urdf.py
@@ -1,0 +1,115 @@
+"""
+Generate G1_autosim.urdf by prepending virtual base joints to the original
+g1_29dof_with_hand.urdf. The virtual joints (base_x, base_y, base_yaw) mirror
+the same approach used in X7S, allowing A*+P-controller navigation to drive the
+robot via joint position commands in Isaac Lab.
+
+Usage:
+    python generate_urdf.py
+Output:
+    G1_autosim.urdf (in the same directory as this script)
+"""
+
+from pathlib import Path
+
+ORIGINAL_URDF = (
+    Path(__file__).parent.parent.parent.parent.parent.parent
+    / "core/mdp/actions/wbc_policy/robot_model/g1/g1_29dof_with_hand.urdf"
+)
+OUTPUT_URDF = Path(__file__).parent / "G1_autosim.urdf"
+
+VIRTUAL_BASE_PREAMBLE = """\
+  <!-- ===== Virtual base joints (autosim addition) ===== -->
+  <!-- These three joints replace the original floating_base_joint and allow  -->
+  <!-- Isaac Lab to move the whole robot via joint position commands, matching  -->
+  <!-- the same pattern used in X7S.                                           -->
+
+  <link name="world_link"/>
+
+  <link name="base_x_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_x_joint" type="prismatic">
+    <parent link="world_link"/>
+    <child link="base_x_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-50" upper="50" effort="100" velocity="1000"/>
+  </joint>
+
+  <link name="base_y_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_y_joint" type="prismatic">
+    <parent link="base_x_link"/>
+    <child link="base_y_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-50" upper="50" effort="100" velocity="1000"/>
+  </joint>
+
+  <link name="base_yaw_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="base_yaw_joint" type="revolute">
+    <parent link="base_y_link"/>
+    <child link="base_yaw_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-6.28159" upper="6.28159" effort="100" velocity="1000"/>
+  </joint>
+
+  <joint name="base_to_pelvis" type="fixed">
+    <parent link="base_yaw_link"/>
+    <child link="pelvis"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <!-- ===== End of virtual base joints ===== -->
+"""
+
+
+def generate():
+    original = ORIGINAL_URDF.read_text(encoding="utf-8")
+
+    # Remove the mujoco block (not needed by cuRobo / Isaac Lab URDF loader)
+    import re
+    original = re.sub(r"\s*<mujoco>.*?</mujoco>", "", original, flags=re.DOTALL)
+
+    # Remove the commented-out floating_base_joint block so the file is clean
+    original = re.sub(r"<!--.*?-->", "", original, flags=re.DOTALL)
+
+    # Find the insertion point: right before the first <link name="pelvis">
+    insert_marker = '<link name="pelvis">'
+    idx = original.find(insert_marker)
+    if idx == -1:
+        raise RuntimeError("Could not find '<link name=\"pelvis\">' in the original URDF.")
+
+    output = original[:idx] + VIRTUAL_BASE_PREAMBLE + original[idx:]
+
+    # Rename robot tag for clarity
+    output = output.replace('name="g1_29dof_with_hand"', 'name="g1_autosim"', 1)
+
+    OUTPUT_URDF.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_URDF.write_text(output, encoding="utf-8")
+    print(f"Written: {OUTPUT_URDF}")
+    print(f"Source:  {ORIGINAL_URDF}")
+
+
+if __name__ == "__main__":
+    generate()

--- a/lw_benchhub/autosim/content/configs/robot/g1_autosim.yml
+++ b/lw_benchhub/autosim/content/configs/robot/g1_autosim.yml
@@ -1,0 +1,132 @@
+robot_cfg:
+
+  kinematics:
+    use_usd_kinematics: False
+    usd_robot_root: "/g1_autosim"
+    urdf_path: "G1_autosim.urdf"          # relative to robot_config_root_path (g1/ dir)
+    asset_root_path: "."                   # meshes are resolved from the urdf file dir
+
+    base_link: "world_link"
+    ee_link: "right_hand_palm_link"        # right-hand end-effector
+
+    # Extra tracked links (left ee for dual-arm tasks)
+    link_names: ["right_hand_palm_link", "left_hand_palm_link"]
+
+    collision_link_names:
+      [
+        "pelvis",
+        "torso_link",
+        "left_shoulder_pitch_link",  "left_shoulder_roll_link",  "left_shoulder_yaw_link",
+        "left_elbow_link",
+        "left_wrist_roll_link",      "left_wrist_pitch_link",    "left_wrist_yaw_link",
+        "left_hand_palm_link",
+        "right_shoulder_pitch_link", "right_shoulder_roll_link", "right_shoulder_yaw_link",
+        "right_elbow_link",
+        "right_wrist_roll_link",     "right_wrist_pitch_link",   "right_wrist_yaw_link",
+        "right_hand_palm_link",
+      ]
+
+    collision_spheres: "spheres/collision_g1_autosim.yml"
+    collision_sphere_buffer: 0.002
+    extra_collision_spheres: {"right_hand_palm_link": 20, "left_hand_palm_link": 20}
+    use_global_cumul: True
+
+    self_collision_ignore:
+      {
+        "pelvis":     ["torso_link", "left_shoulder_pitch_link", "right_shoulder_pitch_link"],
+        "torso_link": ["left_shoulder_pitch_link", "right_shoulder_pitch_link"],
+        "left_shoulder_pitch_link":  ["left_shoulder_roll_link"],
+        "left_shoulder_roll_link":   ["left_shoulder_yaw_link"],
+        "left_shoulder_yaw_link":    ["left_elbow_link"],
+        "left_elbow_link":           ["left_wrist_roll_link"],
+        "left_wrist_roll_link":      ["left_wrist_pitch_link"],
+        "left_wrist_pitch_link":     ["left_wrist_yaw_link"],
+        "left_wrist_yaw_link":       ["left_hand_palm_link"],
+        "right_shoulder_pitch_link": ["right_shoulder_roll_link"],
+        "right_shoulder_roll_link":  ["right_shoulder_yaw_link"],
+        "right_shoulder_yaw_link":   ["right_elbow_link"],
+        "right_elbow_link":          ["right_wrist_roll_link"],
+        "right_wrist_roll_link":     ["right_wrist_pitch_link"],
+        "right_wrist_pitch_link":    ["right_wrist_yaw_link"],
+        "right_wrist_yaw_link":      ["right_hand_palm_link"],
+      }
+
+    self_collision_buffer: {}
+
+    mesh_link_names:
+      [
+        "pelvis",
+        "torso_link",
+        "left_shoulder_pitch_link",  "left_shoulder_roll_link",  "left_shoulder_yaw_link",
+        "left_elbow_link",
+        "left_wrist_roll_link",      "left_wrist_pitch_link",    "left_wrist_yaw_link",
+        "left_hand_palm_link",
+        "right_shoulder_pitch_link", "right_shoulder_roll_link", "right_shoulder_yaw_link",
+        "right_elbow_link",
+        "right_wrist_roll_link",     "right_wrist_pitch_link",   "right_wrist_yaw_link",
+        "right_hand_palm_link",
+      ]
+
+    # Joints that are fixed during planning.
+    # NOTE: Only joints ON the kinematic chain (world_link → right_hand_palm_link,
+    # with left_hand_palm_link as a tracked branch) can be locked.
+    # Leg joints (hip/knee/ankle) branch off pelvis and are NOT on the chain → excluded.
+    # Finger joints are descendants of the EE palm links and are NOT on the chain → excluded.
+    lock_joints:
+      {
+        # Waist (on chain: pelvis → waist_yaw → waist_roll → torso)
+        "waist_yaw_joint":   0.0,
+        "waist_roll_joint":  0.0,
+        "waist_pitch_joint": 0.0,
+        # Left arm (locked; right arm is planned; left_hand_palm_link is a tracked link)
+        "left_shoulder_pitch_joint": 0.0,
+        "left_shoulder_roll_joint":  0.3,
+        "left_shoulder_yaw_joint":   0.0,
+        "left_elbow_joint":          0.0,
+        "left_wrist_roll_joint":     0.0,
+        "left_wrist_pitch_joint":    0.0,
+        "left_wrist_yaw_joint":      0.0,
+      }
+
+    extra_links: null
+
+    cspace:
+      joint_names:
+        [
+          # Virtual base joints (navigation in planner state only)
+          "base_x_joint",
+          "base_y_joint",
+          "base_yaw_joint",
+          # Right arm (7 DoF)
+          "right_shoulder_pitch_joint",
+          "right_shoulder_roll_joint",
+          "right_shoulder_yaw_joint",
+          "right_elbow_joint",
+          "right_wrist_roll_joint",
+          "right_wrist_pitch_joint",
+          "right_wrist_yaw_joint",
+        ]
+
+      retract_config:
+        [
+          0.0, 0.0, 0.0,          # base
+          0.0, -0.3, 0.0, 0.0, 0.0, 0.0, 0.0,  # right arm
+        ]
+
+      null_space_weight:
+        [
+          1.0, 1.0, 1.0,
+          1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ]
+
+      cspace_distance_weight:
+        [
+          1.0, 1.0, 1.0,
+          1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ]
+
+      max_jerk: 500.0
+      max_acceleration: 500.0
+
+planner:
+  frame_bias: [0.0, 0.0, 0.0]

--- a/lw_benchhub/autosim/content/configs/robot/spheres/collision_g1_autosim.yml
+++ b/lw_benchhub/autosim/content/configs/robot/spheres/collision_g1_autosim.yml
@@ -1,0 +1,141 @@
+# cuRobo collision spheres for G1 (autosim variant, right-arm planning)
+#
+# Coordinate convention: each center is in the link's LOCAL frame.
+# Radii are conservative estimates based on G1 link geometry.
+# Only links in or near the planning chain are listed; locked/leg links
+# that are far from the workspace are omitted for performance.
+#
+# Planning chain: world_link → base_x/y/yaw (virtual) → pelvis → torso_link
+#                 → right_shoulder_pitch → ... → right_hand_palm_link
+#
+# Left arm spheres are included (locked but physically present) to avoid
+# body-world and body-self collisions during navigation.
+
+collision_spheres:
+
+  # ── Pelvis ────────────────────────────────────────────────────────────────
+  # Roughly box-shaped, ~0.28 m wide × 0.18 m deep × 0.18 m tall.
+  # Inertia origin: [0, 0, -0.076]
+  pelvis:
+    - "center": [0.0,  0.0,  0.0]
+      "radius": 0.12
+    - "center": [0.0,  0.0, -0.12]
+      "radius": 0.10
+
+  # ── Torso ─────────────────────────────────────────────────────────────────
+  # Tall chest link; inertia origin: [0.003, 0, 0.154]
+  # Spans roughly z = 0 … 0.40 m in the torso_link frame.
+  torso_link:
+    - "center": [0.0,  0.0, 0.0]
+      "radius": 0.13
+    - "center": [0.02, 0.0, 0.10]
+      "radius": 0.13
+    - "center": [0.02, 0.0, 0.20]
+      "radius": 0.12
+    - "center": [0.02, 0.0, 0.32]
+      "radius": 0.11
+    # Shoulder-width bloat (left/right) to protect shoulder joints
+    - "center": [0.0,  0.12, 0.30]
+      "radius": 0.07
+    - "center": [0.0, -0.12, 0.30]
+      "radius": 0.07
+
+  # ── Right arm ─────────────────────────────────────────────────────────────
+
+  # shoulder_pitch: small link bridging torso→roll joint
+  # Joint to next: [0, -0.038, -0.014]; inertia: [0, -0.036, -0.012]
+  right_shoulder_pitch_link:
+    - "center": [0.0, -0.025, -0.012]
+      "radius": 0.045
+
+  # shoulder_roll: ~10 cm link dropping toward shoulder_yaw
+  # Joint to next: [0, -0.006, -0.103]; inertia: [-0.000, -0.007, -0.063]
+  right_shoulder_roll_link:
+    - "center": [0.0, -0.007, -0.025]
+      "radius": 0.042
+    - "center": [0.0, -0.007, -0.075]
+      "radius": 0.038
+
+  # shoulder_yaw: ~8 cm link bridging toward elbow
+  # Joint to next: [0.016, 0, -0.081]; inertia: [0.011, 0.003, -0.072]
+  right_shoulder_yaw_link:
+    - "center": [0.010, -0.003, -0.030]
+      "radius": 0.038
+    - "center": [0.013, -0.002, -0.072]
+      "radius": 0.035
+
+  # elbow: forearm link, ~10 cm in x direction
+  # Joint to next: [0.100, -0.002, -0.010]; inertia: [0.065, -0.004, -0.010]
+  right_elbow_link:
+    - "center": [0.025, -0.004, -0.010]
+      "radius": 0.035
+    - "center": [0.065, -0.004, -0.010]
+      "radius": 0.030
+
+  # wrist_roll: small link, ~3.8 cm to next joint
+  # inertia: [0.017, -0.001, 0.000]
+  right_wrist_roll_link:
+    - "center": [0.017, -0.001, 0.0]
+      "radius": 0.025
+
+  # wrist_pitch: ~4.6 cm to next joint
+  # inertia: [0.023, 0.001, -0.001]
+  right_wrist_pitch_link:
+    - "center": [0.023, 0.001, 0.0]
+      "radius": 0.025
+
+  # wrist_yaw: ~4.15 cm to palm joint
+  # inertia: [0.022, 0.000, 0.001]
+  right_wrist_yaw_link:
+    - "center": [0.022, 0.0, 0.0]
+      "radius": 0.025
+
+  # hand_palm: end-effector link; extends ~0.06 m in x
+  # inertia: [0.062, 0.001, -0.001]
+  right_hand_palm_link:
+    - "center": [0.025, 0.0, 0.0]
+      "radius": 0.025
+    - "center": [0.060, 0.001, 0.0]
+      "radius": 0.020
+
+  # ── Left arm (locked joints — spheres protect against body/world hits) ────
+
+  left_shoulder_pitch_link:
+    - "center": [0.0, 0.025, -0.012]
+      "radius": 0.045
+
+  left_shoulder_roll_link:
+    - "center": [0.0,  0.007, -0.025]
+      "radius": 0.042
+    - "center": [0.0,  0.007, -0.075]
+      "radius": 0.038
+
+  left_shoulder_yaw_link:
+    - "center": [0.010, 0.003, -0.030]
+      "radius": 0.038
+    - "center": [0.013, 0.002, -0.072]
+      "radius": 0.035
+
+  left_elbow_link:
+    - "center": [0.025, 0.004, -0.010]
+      "radius": 0.035
+    - "center": [0.065, 0.004, -0.010]
+      "radius": 0.030
+
+  left_wrist_roll_link:
+    - "center": [0.017, 0.001, 0.0]
+      "radius": 0.025
+
+  left_wrist_pitch_link:
+    - "center": [0.023, -0.001, 0.0]
+      "radius": 0.025
+
+  left_wrist_yaw_link:
+    - "center": [0.022, 0.0, 0.0]
+      "radius": 0.025
+
+  left_hand_palm_link:
+    - "center": [0.025, 0.0, 0.0]
+      "radius": 0.025
+    - "center": [0.060, -0.001, 0.0]
+      "radius": 0.020

--- a/lw_benchhub/autosim/isaaclab_tasks/g1_lift_cube_cfg.py
+++ b/lw_benchhub/autosim/isaaclab_tasks/g1_lift_cube_cfg.py
@@ -1,0 +1,225 @@
+"""Isaac Lab scene + env config for G1 cube-lift autosim.
+
+Scene layout (units: metres, world frame):
+  - G1 robot  : spawned at (0, 0, 0.8) floating via virtual base joints
+  - Table      : at (0.6, 0, 0), packing table (≈ 1.0 m tall, non-instanceable)
+  - Cube       : at (0.6, 0, 1.025)  ← on top of the table
+  - Ground plane: z = -1.05 (below table)
+"""
+
+import torch
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.envs import ManagerBasedRLEnv, ManagerBasedRLEnvCfg, mdp
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
+from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
+from isaaclab.sim.schemas.schemas_cfg import MassPropertiesCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+import lw_benchhub.core.mdp as lw_benchhub_mdp
+from lw_benchhub.core.robots.unitree.assets_cfg import G1_CFG
+
+
+# ---------------------------------------------------------------------------
+# Scene
+# ---------------------------------------------------------------------------
+
+@configclass
+class G1LiftCubeSceneCfg(InteractiveSceneCfg):
+    """Scene with G1 robot, a table, and a cube."""
+
+    robot: ArticulationCfg = G1_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    # Table the robot stands in front of
+    table = AssetBaseCfg(
+        prim_path="{ENV_REGEX_NS}/Table",
+        init_state=AssetBaseCfg.InitialStateCfg(
+            pos=[0.6, 0.0, 0.0],
+            rot=[0.707, 0.0, 0.0, 0.707],
+        ),
+        spawn=UsdFileCfg(
+            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/PackingTable/packing_table.usd",
+        ),
+    )
+
+    # Target object — load from local USDA that has PhysicsRigidBodyAPI already applied.
+    # Using UsdFileCfg (same pattern as the Franka lift-cube reference) avoids the
+    # CuboidCfg / define_rigid_body_properties issue in this IsaacLab version.
+    cube: RigidObjectCfg = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        init_state=RigidObjectCfg.InitialStateCfg(
+            pos=[0.6, 0.0, 1.025],
+            rot=[1, 0, 0, 0],
+        ),
+        spawn=UsdFileCfg(
+            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/blue_block.usd",
+            rigid_props=RigidBodyPropertiesCfg(
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=1,
+                max_angular_velocity=1000.0,
+                max_linear_velocity=1000.0,
+                max_depenetration_velocity=5.0,
+                disable_gravity=False,
+            ),
+            mass_props=MassPropertiesCfg(mass=0.1),
+        ),
+    )
+
+    plane = AssetBaseCfg(
+        prim_path="/World/GroundPlane",
+        init_state=AssetBaseCfg.InitialStateCfg(pos=[0, 0, -1.05]),
+        spawn=GroundPlaneCfg(),
+    )
+
+    light = AssetBaseCfg(
+        prim_path="/World/light",
+        spawn=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Actions  (names must match what G1ActionAdapter expects)
+# ---------------------------------------------------------------------------
+
+@configclass
+class G1ActionsCfg:
+    """Action terms for G1 autosim.
+
+    Action vector layout:
+        [0:4]   base_action   (loco cmd: vx, vy, vyaw, mode)
+        [4:11]  right_arm     (absolute joint position)
+        [11:18] left_arm      (absolute joint position)
+        [18:32] gripper       (14 finger joints, absolute position)
+    """
+
+    base_action: lw_benchhub_mdp.LegPositionActionCfg = lw_benchhub_mdp.LegPositionActionCfg(
+        asset_name="robot",
+        joint_names=[
+            "left_hip_pitch_joint", "right_hip_pitch_joint", "left_hip_roll_joint",
+            "right_hip_roll_joint", "left_hip_yaw_joint", "right_hip_yaw_joint",
+            "left_knee_joint", "right_knee_joint", "left_ankle_pitch_joint",
+            "right_ankle_pitch_joint", "left_ankle_roll_joint", "right_ankle_roll_joint",
+        ],
+        body_name="base",
+        scale=1.0,
+        loco_config="g1_loco.yaml",
+        squat_config="g1_squat.yaml",
+    )
+
+    right_arm_action: mdp.JointPositionActionCfg = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=[
+            "right_shoulder_pitch_joint",
+            "right_shoulder_roll_joint",
+            "right_shoulder_yaw_joint",
+            "right_elbow_joint",
+            "right_wrist_roll_joint",
+            "right_wrist_pitch_joint",
+            "right_wrist_yaw_joint",
+        ],
+        scale=1.0,
+        use_default_offset=False,
+    )
+
+    left_arm_action: mdp.JointPositionActionCfg = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=[
+            "left_shoulder_pitch_joint",
+            "left_shoulder_roll_joint",
+            "left_shoulder_yaw_joint",
+            "left_elbow_joint",
+            "left_wrist_roll_joint",
+            "left_wrist_pitch_joint",
+            "left_wrist_yaw_joint",
+        ],
+        scale=1.0,
+        use_default_offset=False,
+    )
+
+    gripper_action: mdp.JointPositionActionCfg = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=[
+            "right_hand_index_0_joint",  "right_hand_index_1_joint",
+            "right_hand_middle_0_joint", "right_hand_middle_1_joint",
+            "right_hand_thumb_0_joint",  "right_hand_thumb_1_joint",  "right_hand_thumb_2_joint",
+            "left_hand_index_0_joint",   "left_hand_index_1_joint",
+            "left_hand_middle_0_joint",  "left_hand_middle_1_joint",
+            "left_hand_thumb_0_joint",   "left_hand_thumb_1_joint",   "left_hand_thumb_2_joint",
+        ],
+        scale=1.0,
+        use_default_offset=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Observations / Terminations / Events (minimal)
+# ---------------------------------------------------------------------------
+
+@configclass
+class G1ObservationsCfg:
+    @configclass
+    class PolicyCfg(ObsGroup):
+        actions   = ObsTerm(func=mdp.last_action)
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = False
+
+    policy: PolicyCfg = PolicyCfg()
+
+
+def _cube_lifted(env: ManagerBasedRLEnv) -> torch.Tensor:
+    return env.scene["cube"].data.root_pos_w[:, 2] > 0.85
+
+
+@configclass
+class G1RewardsCfg:
+    pass
+
+
+@configclass
+class G1EventCfg:
+    pass
+
+
+@configclass
+class G1TerminationsCfg:
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+    success  = DoneTerm(func=_cube_lifted)
+
+
+# ---------------------------------------------------------------------------
+# Top-level env config
+# ---------------------------------------------------------------------------
+
+@configclass
+class G1LiftCubeEnvCfg(ManagerBasedRLEnvCfg):
+    scene: G1LiftCubeSceneCfg = G1LiftCubeSceneCfg(
+        num_envs=1, env_spacing=3.0, replicate_physics=False
+    )
+    observations: G1ObservationsCfg = G1ObservationsCfg()
+    actions:      G1ActionsCfg      = G1ActionsCfg()
+    terminations: G1TerminationsCfg = G1TerminationsCfg()
+    rewards: G1RewardsCfg = G1RewardsCfg()
+    events:  G1EventCfg   = G1EventCfg()
+
+    def __post_init__(self):
+        self.decimation      = 2
+        self.episode_length_s = 60.0
+        self.sim.dt           = 0.01   # 100 Hz physics
+        self.sim.render_interval = 2
+        self.sim.use_fabric   = False  # disable fabric for compatibility
+
+        self.sim.physx.bounce_threshold_velocity          = 0.01
+        self.sim.physx.gpu_found_lost_aggregate_pairs_capacity = 1024 * 1024 * 4
+        self.sim.physx.gpu_total_aggregate_pairs_capacity  = 16 * 1024
+        self.sim.physx.friction_correlation_distance       = 0.00625

--- a/lw_benchhub/autosim/pipelines/g1_lift_cube.py
+++ b/lw_benchhub/autosim/pipelines/g1_lift_cube.py
@@ -1,0 +1,161 @@
+"""G1 autosim pipeline — RoboCasa kitchen variant.
+
+Uses a RoboCasa kitchen scene (PnPCounterToMicrowave) so that all objects
+come with RigidBodyAPI already baked into their USD files.
+
+Robot:   G1 loco controller variant (leg locomotion + dual arms + hands)
+Task:    Open microwave door
+Scene:   RoboCasa kitchen  robocasakitchen-2-2
+Planner: cuRobo right-arm planning (g1_autosim.yml)
+Nav:     A* + leg locomotion controller (no virtual sliding base)
+"""
+
+from pathlib import Path
+
+import torch
+from autosim.core.pipeline import AutoSimPipeline, AutoSimPipelineCfg
+from autosim.core.types import EnvExtraInfo
+from autosim.decomposers import LLMDecomposerCfg
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.utils import configclass
+
+from lw_benchhub.autosim.action_adapters.g1_action_adapter_cfg import G1ActionAdapterCfg
+
+_CUROBO_ROOT = Path(__file__).parent.parent / "content"
+_G1_URDF_DIR = Path(__file__).parent.parent / "content/assets/robot/g1"
+
+
+@configclass
+class G1LiftCubePipelineCfg(AutoSimPipelineCfg):
+    """Pipeline configuration for G1 RoboCasa kitchen microwave opening."""
+
+    decomposer:     LLMDecomposerCfg   = LLMDecomposerCfg()
+    action_adapter: G1ActionAdapterCfg = G1ActionAdapterCfg()
+
+    def __post_init__(self):
+        # ---- Navigation ----
+        self.skills.moveto.extra_cfg.local_planner.max_linear_velocity  = 0.25
+        self.skills.moveto.extra_cfg.local_planner.max_angular_velocity = 1.0
+        self.skills.moveto.extra_cfg.local_planner.predict_time         = 0.4
+        self.skills.moveto.extra_cfg.global_planner.safety_distance     = 0.5
+        self.skills.moveto.extra_cfg.global_planner.proximity_weight    = 3.0
+        self.skills.moveto.extra_cfg.waypoint_tolerance                 = 0.25
+        self.skills.moveto.extra_cfg.goal_tolerance                     = 0.30
+        self.skills.moveto.extra_cfg.yaw_tolerance                      = 0.01
+        self.skills.moveto.extra_cfg.use_dwa                            = False
+        self.skills.moveto.extra_cfg.sampling_radius                    = 0.8
+
+        # ---- Occupancy map (RoboCasa kitchen floor) ----
+        self.occupancy_map.floor_prim_suffix = "Scene/floor_room"
+
+        # ---- cuRobo ----
+        self.motion_planner.robot_config_file  = "g1_autosim.yml"
+        self.motion_planner.curobo_config_path = str(_CUROBO_ROOT / "configs" / "robot")
+        # Point cuRobo asset root at the g1 directory so the relative URDF
+        # path inside g1_autosim.yml resolves correctly.
+        self.motion_planner.curobo_asset_path  = str(_G1_URDF_DIR)
+        self.motion_planner.world_ignore_subffixes = ["Scene/floor_room"]
+        # Focus collision world around the microwave area.
+        self.motion_planner.world_only_subffixes = ["Scene/microwave_main_group"]
+        self.skills.pull.extra_cfg.move_offset = 0.25
+        self.skills.pull.extra_cfg.move_axis = "-x"
+        self.max_steps = 1000
+
+
+class G1LiftCubePipeline(AutoSimPipeline):
+    """Pipeline that opens microwave door with the G1 right arm.
+
+    Scene loading uses RoboCasa task assets and the G1 locomotion robot config.
+    """
+
+    _TASK_NAME = "Robocasa-OpenMicrowave-G1-Autosim-v0"
+
+    def __init__(self, cfg: AutoSimPipelineCfg):
+        super().__init__(cfg)
+
+    # ------------------------------------------------------------------
+    # Environment loading
+    # ------------------------------------------------------------------
+
+    def load_env(self) -> ManagerBasedEnv:
+        import gymnasium as gym
+        from lw_benchhub.utils.env import parse_env_cfg, ExecuteMode
+        from lw_benchhub.autosim.isaaclab_tasks.g1_lift_cube_cfg import (
+            G1ActionsCfg,
+            G1ObservationsCfg,
+            G1EventCfg,
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Load a RoboCasa kitchen scene with G1 loco robot config.
+        # ------------------------------------------------------------------
+        env_cfg = parse_env_cfg(
+            scene_backend="robocasa",
+            task_backend="robocasa",
+            task_name="OpenMicrowave",
+            robot_name="G1-Loco-Controller",
+            scene_name="robocasakitchen-2-2",
+            robot_scale=1.0,
+            device="cpu",
+            num_envs=1,
+            use_fabric=False,
+            first_person_view=False,
+            enable_cameras=False,
+            execute_mode=ExecuteMode.TRAIN,
+            usd_simplify=False,
+            seed=42,
+            sources=["objaverse", "lightwheel", "aigen_objs"],
+            object_projects=[],
+            rl_name=None,
+            headless_mode=False,
+        )
+
+        # ------------------------------------------------------------------
+        # 2. Replace default robot action/obs/event with autosim-compatible
+        #    terms while keeping G1 leg locomotion in base_action.
+        # ------------------------------------------------------------------
+        env_cfg.actions = G1ActionsCfg()
+
+        # Minimal observations — autosim reads scene data directly.
+        env_cfg.observations = G1ObservationsCfg()
+
+        # Empty events — autosim manages resets itself.
+        env_cfg.events = G1EventCfg()
+
+        # Disable built-in terminations — autosim manages episode endings.
+        env_cfg.terminations.time_out = None
+
+        # ------------------------------------------------------------------
+        # 3. Register and instantiate the env.
+        # ------------------------------------------------------------------
+        gym.register(
+            id=self._TASK_NAME,
+            entry_point="isaaclab.envs:ManagerBasedRLEnv",
+            kwargs={},
+            disable_env_checker=True,
+        )
+
+        return gym.make(self._TASK_NAME, cfg=env_cfg).unwrapped
+
+    # ------------------------------------------------------------------
+    # Task metadata for the LLM decomposer
+    # ------------------------------------------------------------------
+
+    def get_env_extra_info(self) -> EnvExtraInfo:
+        env_info = EnvExtraInfo(
+            task_name="Robocasa-Task-OpenMicrowave",
+            objects=list(self._env.scene.keys()),
+            robot_name="robot",
+            robot_base_link_name="pelvis",           # G1 physical base link
+            ee_link_name="right_wrist_yaw_link",  # last rigid body before palm in g1_three_fingers.usd
+            object_reach_target_poses={
+                # Approximate pre-grasp on microwave handle.
+                "microwave_main_group": [
+                    torch.tensor([0.05, -0.22, 0.12, 0.707, 0.0, 0.0, 0.707]),
+                ],
+            },
+        )
+        # Compatibility with autosim versions whose Reach skill expects optional
+        # extra-EEF pose fields/methods on EnvExtraInfo.
+        env_info.object_extra_reach_target_poses = {}
+        return env_info

--- a/run_autosim.py
+++ b/run_autosim.py
@@ -1,0 +1,42 @@
+"""Run an autosim pipeline registered in lw_benchhub."""
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+parser = argparse.ArgumentParser(description="Run an lw_benchhub autosim pipeline.")
+parser.add_argument(
+    "--pipeline_id",
+    type=str,
+    default="LWBenchhub-Autosim-G1OpenMicrowavePipeline-v0",
+    help="Registered pipeline ID.",
+)
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+
+app_launcher = AppLauncher(vars(args_cli))
+simulation_app = app_launcher.app
+
+import lw_benchhub.autosim  # noqa: F401 — triggers pipeline registration
+from lw_benchhub.autosim.compat_autosim import patch_curobo_config, patch_env_extra_info, patch_reach_skill
+from autosim import make_pipeline
+
+
+def main():
+    # EnvExtraInfo compatibility is needed by both X7S and G1 pipelines.
+    patch_env_extra_info()
+
+    # Reach/curobo runtime compatibility patches are only needed for G1 branch.
+    if args_cli.pipeline_id in {
+        "LWBenchhub-Autosim-G1OpenMicrowavePipeline-v0",
+        "LWBenchhub-Autosim-G1LiftCubePipeline-v0",
+    }:
+        patch_reach_skill()
+        patch_curobo_config()
+
+    pipeline = make_pipeline(args_cli.pipeline_id)
+    pipeline.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- G1 action adapter and config (arm + gripper + loco base)
- G1LiftCubePipeline and G1OpenMicrowavePipeline registrations
- IsaacLab scene cfg using packing_table.usd (non-instanceable, consistent with upstream G1 tasks)
- Runtime compat patches for mixed autosim versions (compat_autosim.py)
- Robot assets: G1_autosim.urdf, curobo configs, collision spheres
Currently still under development and not the final submitted version.